### PR TITLE
Enable travis compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+---
+language: cpp
+install: cd build && cmake ..
+compiler:
+  - gcc
+  - clang
+
+script: make
+
+addons:
+  apt:
+    sources:
+      - george-edison55-precise-backports
+    packages:
+      - cmake-data
+      - cmake
+
+before_script:
+


### PR DESCRIPTION
Travis compilation on commit with clang and gcc on Ubuntu 14.04.

fix richardwaynefedorajr/DesignPatternsCpp#5